### PR TITLE
7 refactor task handle api add blocking result and rename non blocking result query to try result

### DIFF
--- a/examples/texec_example.c
+++ b/examples/texec_example.c
@@ -42,8 +42,6 @@ int main(void) {
 
   int ret = 0;
   if (st == TEXEC_STATUS_OK) {
-    texec_task_handle_wait(handle);
-
     int result = -1;
     st = texec_task_handle_result(handle, &result);
     if (st == TEXEC_STATUS_OK) {

--- a/include/texec/task_handle.h
+++ b/include/texec/task_handle.h
@@ -12,10 +12,14 @@ typedef struct texec_task_handle texec_task_handle_t;
 texec_status_t texec_task_handle_retain(texec_task_handle_t* h);
 void texec_task_handle_release(texec_task_handle_t* h);
 
-void texec_task_handle_wait(texec_task_handle_t* h);
+texec_status_t texec_task_handle_try_result(texec_task_handle_t* h, int* out_result);
+texec_status_t texec_task_handle_result(texec_task_handle_t* h, int* out_result);
 bool texec_task_handle_is_done(texec_task_handle_t* h);
 
-texec_status_t texec_task_handle_result(texec_task_handle_t* h, int* out_result);
+static inline texec_status_t texec_task_handle_wait(texec_task_handle_t* h) {
+  int result;
+  return texec_task_handle_result(h, &result);
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR refactors the `task_handle` API by adding a blocking `result` (repurposed existing API), a non-blocking `try_result`, and a blocking `wait` implemented in terms of `result`.